### PR TITLE
fix: google Provider in terraform-gcp-vpc component module | DEVOP-4814

### DIFF
--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -1,8 +1,5 @@
-name: "Semantic Pull Request"
-
-permissions:
-  contents: write
-  pull-requests: write
+name: "semantic-pull-request"
+permissions: read-all
 
 on:
   pull_request:
@@ -13,10 +10,10 @@ on:
 
 jobs:
   main:
-    name: Semantic Pull Request
+    name: semantic-pull-request
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@v5
         name: Semantic Pull Request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,14 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.74.1 # Get the latest from: https://github.com/antonbabenko/pre-commit-terraform/releases
+    rev: v1.92.0 # Get the latest from: https://github.com/antonbabenko/pre-commit-terraform/releases
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
 
     google-beta = {
-      source  = "hashicorp/google"
+      source  = "hashicorp/google-beta"
       version = "~> 5.0"
     }
   }

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -4,12 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.0"
-    }
-
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "~> 5.0"
+      version = ">= 5.0, < 6.0"
     }
   }
 }


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

This PR solves below error:

```
│ Warning: Duplicate required provider

│

│   on modules/terraform-gcp-vpc/modules/vpc/versions.tf line 5, in terraform:

│    5:     google = {

│    6:       source  = "hashicorp/google"

│    7:       version = "~> 5.0"

│    8:     }

│

│ Provider hashicorp/google with the local name "google" was previously

│ required as "google-beta". A provider can only be required once within

│ required_providers.

│

│ (and 3 more similar warnings elsewhere)
```

* <!-- WRITE A SHORT DESCRIPTION OF CHANGES -->

<!-- Reviewable:start -->
- - -
[<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-vpc/23)
<!-- Reviewable:end -->
